### PR TITLE
Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 NodeJS Client Library for the [bitcoin.de](https://www.bitcoin.de/de) Trading API
 
+This fork :fork_and_knife: bei [@neuhaus](https://github.com/neuhaus) replaces callbacks with ES6 Promises. 
+It is based on the @mojoaxel [fork](https://github.com/mojoaxel/nodejs-bitcoin-de-api) that added support for APi v2.
+The [original version](https://github.com/4ley/nodejs-bitcoin-de-api) is by @4ley.
+
 ## Installation
 
 ```
@@ -13,31 +17,31 @@ npm install bitcoinde-api
 ```javascript
 var BitcoindeClient = require('bitcoinde-api');
 var bitcoinde = new BitcoindeClient({
-  key: 'api_key',
-  secret: 'api_secret'
+	key: 'api_key',
+	secret: 'api_secret'
 });
 
 // Orderbook
 bitcoinde.get('orders', { type: 'sell' })
 	.then((result) => {
-        console.log(result.orders);
+		console.log(result.orders);
 	})
 	.catch((error) => {
-        console.error(error);
-    });
+		console.error(error);
+	});
 
 // Account Info
 bitcoinde.get('account', null)
 	.then((result) => {
-        console.log(result.data);
+		console.log(result.data);
 	})
 	.catch((error) => {
-        console.error(error);
+		console.error(error);
 	});
 
 // Catch Error Event
 bitcoinde.on('error', function(error) {
-    console.error(error);
+	console.error(error);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@ var bitcoinde = new BitcoindeClient({
 });
 
 // Orderbook
-bitcoinde.get('orders', { type: 'sell' }, function(error, result) {
-    if(error) {
-        console.error(error);
-    } else {
+bitcoinde.get('orders', { type: 'sell' })
+	.then((result) => {
         console.log(result.orders);
-    }
-});
+	})
+	.catch((error) => {
+        console.error(error);
+    });
 
 // Account Info
-bitcoinde.get('account', null, function(error, result) {
-    if(error) {
-        console.error(error);
-    } else {
+bitcoinde.get('account', null)
+	.then((result) => {
         console.log(result.data);
-    }
-});
+	})
+	.catch((error) => {
+        console.error(error);
+	});
 
 // Catch Error Event
 bitcoinde.on('error', function(error) {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The [original version](https://github.com/4ley/nodejs-bitcoin-de-api) is by @4le
 ## Installation
 
 ```
-npm install bitcoinde-api
+npm install neuhaus/nodejs-bitcoin-de-api
 ```
 
 ## Example Usage

--- a/README.md
+++ b/README.md
@@ -2,14 +2,10 @@
 
 NodeJS Client Library for the [bitcoin.de](https://www.bitcoin.de/de) Trading API
 
-This fork :fork_and_knife: bei [@neuhaus](https://github.com/neuhaus) replaces callbacks with ES6 Promises. 
-It is based on the @mojoaxel [fork](https://github.com/mojoaxel/nodejs-bitcoin-de-api) that added support for APi v2.
-The [original version](https://github.com/4ley/nodejs-bitcoin-de-api) is by @4ley.
-
 ## Installation
 
 ```
-npm install neuhaus/nodejs-bitcoin-de-api
+npm install bitcoinde-api
 ```
 
 ## Example Usage
@@ -17,31 +13,31 @@ npm install neuhaus/nodejs-bitcoin-de-api
 ```javascript
 var BitcoindeClient = require('bitcoinde-api');
 var bitcoinde = new BitcoindeClient({
-	key: 'api_key',
-	secret: 'api_secret'
+    key: 'api_key',
+    secret: 'api_secret'
 });
 
 // Orderbook
 bitcoinde.get('orders', { type: 'sell' })
-	.then((result) => {
-		console.log(result.orders);
-	})
-	.catch((error) => {
-		console.error(error);
-	});
+    .then((result) => {
+        console.log(result.orders);
+    })
+    .catch((error) => {
+        console.error(error);
+    });
 
 // Account Info
 bitcoinde.get('account', null)
-	.then((result) => {
-		console.log(result.data);
-	})
-	.catch((error) => {
-		console.error(error);
-	});
+    .then((result) => {
+        console.log(result.data);
+    })
+    .catch((error) => {
+        console.error(error);
+    });
 
 // Catch Error Event
 bitcoinde.on('error', function(error) {
-	console.error(error);
+    console.error(error);
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function BitcoindeClient(settings) {
 					return new Promise((resolve, reject) => {
 						let err = new Error('Method ' + method + ' not defined');
 						self.emit('error', err);
-						reject(err)
+						reject(err);
 					});
 			}
 		}
@@ -121,17 +121,17 @@ function BitcoindeClient(settings) {
 				.then((data) => {
 					if(data.errors && data.errors.length) {
 						// can we do something better with data.errors?
-						err = new Error('Bitcoin.de API returned error: '+data.errors[0].message);
+						let err = new Error('bitcoin.de API returned error: ' + data.errors[0].message);
 						self.emit('error', err);
-						reject(err)
+						reject(err);
 					} else {
-						resolve(data)
+						resolve(data);
 					}
 				})
 				.catch((error) => {
-					err = new Error('Error in server response: '+JSON.stringify(error));
+					let err = new Error('Error in server response: ' + JSON.stringify(error));
 					self.emit('error', err);
-					reject(err)
+					reject(err);
 				});
 
 		});
@@ -161,7 +161,7 @@ function BitcoindeClient(settings) {
 			return now + padding + this.counter;
 		};
 	})();
-};
+}
 
 util.inherits(BitcoindeClient, events.EventEmitter);
 

--- a/index.js
+++ b/index.js
@@ -23,51 +23,51 @@ function BitcoindeClient(settings) {
 	if (!config.key) self.emit('error', new Error('required settings "key" is missing'));
 	if (!config.secret) self.emit('error', new Error('required settings "secret" is missing'));
 
-    /**
-     * Initialize necessary properties from EventEmitter
-     */
+	/**
+	 * Initialize necessary properties from EventEmitter
+	 */
 	events.EventEmitter.call(self);
 
-    /**
-     * Perform GET API request
-     * @param  {String}   method   API method
-     * @param  {Object}   params   Arguments to pass to the api call
-     * @return {Object}            The request object
-     */
+	/**
+	 * Perform GET API request
+	 * @param  {String}   method   API method
+	 * @param  {Object}   params   Arguments to pass to the api call
+	 * @return {Object}            The request object
+	 */
 	self.get = function(method, params) {
 		var url = config.url+'/'+config.version+'/'+method;
 		return rawRequest('get', url, params);
 	};
 
-    /**
-     * Perform POST API request
-     * @param  {String}   method   API method
-     * @param  {Object}   params   Arguments to pass to the api call
-     * @return {Object}            The request object
-     */
-    self.post = function(method, params) {
-        var url = config.url+'/'+config.version+'/'+method;
-        return rawRequest('post', url, params);
-    };
+	/**
+	 * Perform POST API request
+	 * @param  {String}   method   API method
+	 * @param  {Object}   params   Arguments to pass to the api call
+	 * @return {Object}            The request object
+	 */
+	self.post = function(method, params) {
+		var url = config.url+'/'+config.version+'/'+method;
+		return rawRequest('post', url, params);
+	};
 
-    /**
-     * Perform DELETE API request
-     * @param  {String}   method   API method
-     * @param  {Object}   params   Arguments to pass to the api call
-     * @return {Object}            The request object
-     */
-    self.delete = function(method, params) {
-        var url = config.url+'/'+config.version+'/'+method;
-        return rawRequest('delete', url, params);
-    };
+	/**
+	 * Perform DELETE API request
+	 * @param  {String}   method   API method
+	 * @param  {Object}   params   Arguments to pass to the api call
+	 * @return {Object}            The request object
+	 */
+	self.delete = function(method, params) {
+		var url = config.url+'/'+config.version+'/'+method;
+		return rawRequest('delete', url, params);
+	};
 
-    /**
-     * Send the actual HTTP request
-     * @param  {String}   method   HTTP method
-     * @param  {String}   url      URL to request
-     * @param  {Object}   params   POST body
-     * @return {Object}            The request object
-     */
+	/**
+	 * Send the actual HTTP request
+	 * @param  {String}   method   HTTP method
+	 * @param  {String}   url      URL to request
+	 * @param  {Object}   params   POST body
+	 * @return {Object}            The request object
+	 */
 	var rawRequest = function(method, url, params) {
 
 		let nonce    = noncer.generate();
@@ -78,43 +78,43 @@ function BitcoindeClient(settings) {
 			json: true
 		};
 
-        if(params) {
-            switch(method) {
-                case 'post':
-                    var queryParams = {};
-                    Object.keys(params).sort().forEach(function(idx) { queryParams[idx] = params[idx]; });
-                    md5Query = crypto.createHash('md5')
+		if (params) {
+			switch(method) {
+				case 'post':
+					var queryParams = {};
+					Object.keys(params).sort().forEach(function(idx) { queryParams[idx] = params[idx]; });
+					md5Query = crypto.createHash('md5')
 						.update(querystring.stringify(queryParams))
 						.digest('hex');
-                    options.form = queryParams;
+					options.form = queryParams;
 					options.method = 'POST';
-                    break;
-                case 'get':
-                    options.url += '?'+querystring.stringify(params);
-                    break;
-                case 'delete':
-                    options.url += '?'+querystring.stringify(params);
+					break;
+				case 'get':
+					options.url += '?'+querystring.stringify(params);
+					break;
+				case 'delete':
+					options.url += '?'+querystring.stringify(params);
 					options.method = 'DELETE';
-                    break;
-                default:
-                    var err = new Error('Method ' + method + ' not defined');
-                    self.emit('error', err);
+					break;
+				default:
 					return new Promise((resolve, reject) => {
+						let err = new Error('Method ' + method + ' not defined');
+						self.emit('error', err);
 						reject(err)
 					});
-            }
-        }
+			}
+		}
 
-        var signature = crypto.createHmac('sha256', config.secret)
+		var signature = crypto.createHmac('sha256', config.secret)
 			.update([method.toUpperCase(), options.url, config.key, nonce, md5Query].join('#'))
 			.digest('hex');
 
-        options.headers = {
-            'User-Agent'     : config.agent,
-            'X-API-KEY'      : config.key,
-            'X-API-NONCE'    : nonce,
-            'X-API-SIGNATURE': signature
-        };
+		options.headers = {
+			'User-Agent'     : config.agent,
+			'X-API-KEY'      : config.key,
+			'X-API-NONCE'    : nonce,
+			'X-API-SIGNATURE': signature
+		};
 
 		return new Promise((resolve, reject) => {
 			requestPromise(options)
@@ -135,32 +135,32 @@ function BitcoindeClient(settings) {
 				});
 
 		});
-    }; // rawRequest
+	}; // rawRequest
 
-    /**
-     * Nonce generator
-     */
-    var noncer = new (function() {
+	/**
+	 * Nonce generator
+	 */
+	var noncer = new (function() {
 
-        // if you call Date.now() too fast it will generate
-        // the same ms, helper to make sure the nonce is
-        // truly unique (supports up to 999 calls per ms).
-        this.generate = function() {
+		// if you call Date.now() too fast it will generate
+		// the same ms, helper to make sure the nonce is
+		// truly unique (supports up to 999 calls per ms).
+		this.generate = function() {
 
-            var now = Date.now();
+			var now = Date.now();
 
-            this.counter = (now === this.last? this.counter + 1 : 0);
-            this.last    = now;
+			this.counter = (now === this.last? this.counter + 1 : 0);
+			this.last    = now;
 
-            // add padding to nonce
-            var padding =
-                this.counter < 10 ? '000' :
-                    this.counter < 100 ? '00' :
-                        this.counter < 1000 ?  '0' : '';
+			// add padding to nonce
+			var padding =
+				this.counter < 10 ? '000' :
+					this.counter < 100 ? '00' :
+						this.counter < 1000 ?  '0' : '';
 
-            return now+padding+this.counter;
-        };
-    })();
+			return now + padding + this.counter;
+		};
+	})();
 };
 
 util.inherits(BitcoindeClient, events.EventEmitter);

--- a/index.js
+++ b/index.js
@@ -83,7 +83,9 @@ function BitcoindeClient(settings) {
                 case 'post':
                     var queryParams = {};
                     Object.keys(params).sort().forEach(function(idx) { queryParams[idx] = params[idx]; });
-                    md5Query = crypto.createHash('md5').update(querystring.stringify(queryParams)).digest('hex');
+                    md5Query = crypto.createHash('md5')
+						.update(querystring.stringify(queryParams))
+						.digest('hex');
                     options.form = queryParams;
 					options.method = 'POST';
                     break;
@@ -95,7 +97,7 @@ function BitcoindeClient(settings) {
 					options.method = 'DELETE';
                     break;
                 default:
-                    var err = new Error('Method ' +method+ ' not defined');
+                    var err = new Error('Method ' + method + ' not defined');
                     self.emit('error', err);
 					return new Promise((resolve, reject) => {
 						reject(err)
@@ -103,14 +105,14 @@ function BitcoindeClient(settings) {
             }
         }
 
-        var signature = crypto.createHmac('sha256', config.secret).update(
-            method.toUpperCase()+'#'+options.url+'#'+config.key+'#'+nonce+'#'+md5Query
-        ).digest('hex');
+        var signature = crypto.createHmac('sha256', config.secret)
+			.update([method.toUpperCase(), options.url, config.key, nonce, md5Query].join('#'))
+			.digest('hex');
 
         options.headers = {
-            'User-Agent': config.agent,
-            'X-API-KEY': config.key,
-            'X-API-NONCE': nonce,
+            'User-Agent'     : config.agent,
+            'X-API-KEY'      : config.key,
+            'X-API-NONCE'    : nonce,
             'X-API-SIGNATURE': signature
         };
 
@@ -140,7 +142,7 @@ function BitcoindeClient(settings) {
      */
     var noncer = new (function() {
 
-        // if you call Date.now() to fast it will generate
+        // if you call Date.now() too fast it will generate
         // the same ms, helper to make sure the nonce is
         // truly unique (supports up to 999 calls per ms).
         this.generate = function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,321 +5,393 @@
   "requires": true,
   "dependencies": {
     "ajv": {
-      "version": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-        "fast-deep-equal": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-        "json-schema-traverse": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "asn1": {
-      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
-      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "asynckit": {
-      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
-      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "bcrypt-pbkdf": {
-      "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+        "tweetnacl": "0.14.5"
       }
     },
     "boom": {
-      "version": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
+        "hoek": "4.2.0"
       }
     },
     "caseless": {
-      "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "co": {
-      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "combined-stream": {
-      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+        "delayed-stream": "1.0.0"
       }
     },
     "core-util-is": {
-      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cryptiles": {
-      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
-          "version": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
+            "hoek": "4.2.0"
           }
         }
       }
     },
     "dashdash": {
-      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        "assert-plus": "1.0.0"
       }
     },
     "delayed-stream": {
-      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "ecc-jsbn": {
-      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+        "jsbn": "0.1.1"
       }
     },
     "extend": {
-      "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extsprintf": {
-      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
     "forever-agent": {
-      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "requires": {
-        "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
       }
     },
     "getpass": {
-      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        "assert-plus": "1.0.0"
       }
     },
     "har-schema": {
-      "version": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-        "har-schema": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "hawk": {
-      "version": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-        "sntp": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.1.0"
       }
     },
     "hoek": {
-      "version": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "http-signature": {
-      "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-        "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-        "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
       }
     },
     "is-typedarray": {
-      "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isstream": {
-      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jsbn": {
-      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
     "json-schema": {
-      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
-      "version": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
-    "json-stable-stringify": {
-      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-      }
-    },
     "json-stringify-safe": {
-      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
-    "jsonify": {
-      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
     "jsprim": {
-      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-        "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-        "verror": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
     "mime-db": {
-      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
       "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
     },
     "mime-types": {
-      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
+        "mime-db": "1.30.0"
       }
     },
     "oauth-sign": {
-      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "performance-now": {
-      "version": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "punycode": {
-      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "querystring": {
-      "version": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "request": {
-      "version": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-        "hawk": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-        "performance-now": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-        "qs": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.3"
       }
     },
     "safe-buffer": {
-      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sntp": {
-      "version": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
+        "hoek": "4.2.0"
       }
     },
     "sshpk": {
-      "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
-        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-        "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-        "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-        "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-        "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
     "stringstream": {
-      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "tough-cookie": {
-      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+        "punycode": "1.4.1"
       }
     },
     "tunnel-agent": {
-      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+        "safe-buffer": "5.1.1"
       }
     },
     "tweetnacl": {
-      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
@@ -329,16 +401,18 @@
       "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
     },
     "uuid": {
-      "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "verror": {
-      "version": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,11 @@
         "assert-plus": "1.0.0"
       }
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -268,6 +273,11 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -283,10 +293,15 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    "query-string": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.0.1.tgz",
+      "integrity": "sha512-aM+MkQClojlNiKkO09tiN2Fv8jM/L7GWIjG2liWeKljlOdOPNWr+bW3KQ+w5V/uKprpezC7fAsAMsJtJ+2rLKA==",
+      "requires": {
+        "decode-uri-component": "0.2.0",
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
+      }
     },
     "request": {
       "version": "2.83.0",
@@ -367,6 +382,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   ],
   "author": "Aley R. (https://github.com/4ley)",
   "contributors": [
-    "Alexander Wunschik <dev@wunschik.net>"
+    "Alexander Wunschik <dev@wunschik.net>",
+    "Sven Neuhaus <sven-github@sven.de>"
   ],
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitcoinde-api",
   "version": "2.0.0",
-  "description": "NodeJS Client Library for the bitcoin.de Trading API",
+  "description": "NodeJS client library with Promises for the bitcoin.de Trading API v2",
   "keywords": [
     "bitcoin.de",
     "bitcoin",
@@ -16,21 +16,21 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "querystring": "^0.2.0",
-    "request": "^2.83.0",
-    "request-promise-native": "^1.0.5",
-    "util-extend": "^1.0.3"
+    "query-string": ">=5.0.1",
+    "request": ">=2.83.0",
+    "request-promise-native": ">=1.0.5",
+    "util-extend": ">=1.0.3"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/4ley/nodejs-bitcoin-de-api"
+    "url": "https://github.com/neuhaus/nodejs-bitcoin-de-api"
   },
   "main": "index.js",
   "engines": {
-    "node": ">=0.10"
+    "node": ">=4.8.7"
   },
   "bugs": {
-    "url": "https://github.com/4ley/nodejs-bitcoin-de-api/issues"
+    "url": "https://github.com/neuhaus/nodejs-bitcoin-de-api/issues"
   },
   "readmeFilename": "README.md"
 }

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/neuhaus/nodejs-bitcoin-de-api"
+    "url": "https://github.com/4ley/nodejs-bitcoin-de-api"
   },
   "main": "index.js",
   "engines": {
     "node": ">=4.8.7"
   },
   "bugs": {
-    "url": "https://github.com/neuhaus/nodejs-bitcoin-de-api/issues"
+    "url": "https://github.com/4ley/nodejs-bitcoin-de-api/issues"
   },
   "readmeFilename": "README.md"
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "querystring": ">=0.2.0",
-    "request": ">=2.27.0",
+    "querystring": "^0.2.0",
+    "request": "^2.83.0",
+    "request-promise-native": "^1.0.5",
     "util-extend": "^1.0.3"
   },
   "repository": {


### PR DESCRIPTION
replace callbacks with Promises
switch to request-promise-native NPM package
update the README to reflect the changes

changed some `var` to `const` or `let`.

Changed "method" to "action" when used in the context of the bitcoin.de API (and not the HTTP method) to avoid confusion.

"delete" now calls rawRequest with "delete", simplifying code

bugfix: switch from querystring module to query-string. Now actually properly sorts the query string without relying on non-standardized interpreter implementation details.
